### PR TITLE
chore: use TypeScript Vite config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/vite.config.d.ts
+++ b/vite.config.d.ts
@@ -1,2 +1,0 @@
-declare const _default: import("vite").UserConfig;
-export default _default;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vite';
-import plugin from '@vitejs/plugin-react';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [plugin()],
+    base: '/',
+    plugins: [react()],
     server: {
         port: 56612,
-    }
-})
+    },
+    build: {
+        outDir: 'dist',
+    },
+});


### PR DESCRIPTION
## Summary
- remove leftover `vite.config.d.ts`
- use TypeScript Vite config with explicit base and build output
- add basic `.gitignore` for dependencies and build output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894e1c17184832980ef028182288f39